### PR TITLE
Add Support for Negative Shifting In `window_ops.shift.shift_array`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Before anything else, please install the git hooks that run automatic scripts during each commit and merge to strip the notebooks of superfluous metadata (and avoid merge conflicts). After cloning the repository, run the following command inside it:
 ```
-nbdev_install_git_hooks
+nbdev_install_hooks
 ```
 
 ## Did you find a bug?

--- a/nbs/shift.ipynb
+++ b/nbs/shift.ipynb
@@ -46,7 +46,7 @@
     "    output_array = np.full_like(input_array, np.nan)\n",
     "    ub = n_samples - offset if offset > 0 else n_samples\n",
     "    lb = offset * -1 if offset < 0 else 0\n",
-    "    for i in range(n_samples - offset):\n",
+    "    for i in range(lb, ub):\n",
     "        output_array[i + offset] = input_array[i]\n",
     "    return output_array"
    ]

--- a/nbs/shift.ipynb
+++ b/nbs/shift.ipynb
@@ -44,6 +44,8 @@
     "def shift_array(input_array: np.ndarray, offset: int) -> np.ndarray:\n",
     "    n_samples = input_array.size\n",
     "    output_array = np.full_like(input_array, np.nan)\n",
+    "    ub = n_samples - offset if offset > 0 else n_samples\n",
+    "    lb = offset * -1 if offset < 0 else 0\n",
     "    for i in range(n_samples - offset):\n",
     "        output_array[i + offset] = input_array[i]\n",
     "    return output_array"
@@ -77,9 +79,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
New behavior:

```python
test_input = np.array([1.0, 1.0])

shift_array(t_input, offset=-1)
```
>`array([1., nan])`

Old behavior:
```python
test_input = np.array([1.0, 1.0])

shift_array(t_input, offset=-1)
```
>`array([1., 8.69623725e-311)` (when compiled with numba, reads out of bounds)

The same code not compiled using numba will throw an `IndexError`:

```python
>>> import numpy as np
>>> def shift_array(input_array: np.ndarray, offset: int) -> np.ndarray:
...     n_samples = input_array.size
...     output_array = np.full_like(input_array, np.nan)
...     for i in range(n_samples - offset):
...         output_array[i + offset] = input_array[i]
...     return output_array
...
>>> x = np.array([1.0, 1.0])
>>> shift_array(x, offset=-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 5, in shift_array
IndexError: index 2 is out of bounds for axis 0 with size 2
>>>
```

This is expected behavior because of numba's [Bounds Checking](https://numba.pydata.org/numba-doc/dev/reference/pysemantics.html#bounds-checking) design. More specifically, an `IndexError` is deliberately not thrown - but we do read from out of bounds. 

This PR adds the ability to shift an array in the opposite direction *without* quietly reading from out of bounds and without enabling bounds checking with `numba.jit(boundscheck=True)`. 